### PR TITLE
use utf8 locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM baseruntime/baseruntime
 
 MAINTAINER "James Antill <james.antill@redhat.com>"
 
+ENV LANG=en_US.utf8 LC_ALL=en_US.UTF-8
+
 ADD server.repo /etc/yum.repos.d
 ADD _copr_rpmsoftwaremanagement-dnf-nightly.repo /etc/yum.repos.d
 


### PR DESCRIPTION
and make python3 shut up:

Python detected LC_CTYPE=C: LC_ALL & LANG coerced to C.UTF-8 (set another locale or PYTHONCOERCECLOCALE=0 to disable this locale coercion behaviour).

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>